### PR TITLE
Feature/login page

### DIFF
--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,4 +1,97 @@
-// TODO: 구현
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import styles from '../styles/Login.module.css';
+
+const ERROR_MESSAGES = {
+  WRONG_PASSWORD: '이메일 또는 비밀번호가 올바르지 않습니다.',
+  FIELD_MISSING: '이메일과 비밀번호를 모두 입력해주세요.',
+};
+
 export default function Login() {
-  return <div>Login</div>;
+  const { login } = useAuth();
+  const navigate = useNavigate();
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setSubmitting(true);
+
+    try {
+      await login(email, password);
+      navigate('/dashboard');
+    } catch (err) {
+      const msg = ERROR_MESSAGES[err.errorCode] || err.message || '로그인에 실패했습니다.';
+      setError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.brand}>
+        <span className={styles.brandPrompt}>&gt;_</span>
+        <span className={styles.brandName}>Code Editor</span>
+      </div>
+
+      <div className={styles.card}>
+        <h1 className={styles.title}>Welcome back</h1>
+        <p className={styles.subtitle}>Sign in to your account</p>
+
+        {error && <div className={styles.errorBanner}>{error}</div>}
+
+        <form onSubmit={handleSubmit} className={styles.form} noValidate>
+          <label className={styles.field}>
+            <span className={styles.label}>Email</span>
+            <div className={styles.inputWrap}>
+              <span className={styles.inputIcon}>✉</span>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="you@example.com"
+                autoComplete="email"
+                required
+                className={styles.input}
+              />
+            </div>
+          </label>
+
+          <label className={styles.field}>
+            <span className={styles.label}>Password</span>
+            <div className={styles.inputWrap}>
+              <span className={styles.inputIcon}>🔒</span>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="••••••••"
+                autoComplete="current-password"
+                required
+                className={styles.input}
+              />
+            </div>
+          </label>
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className={styles.submitBtn}
+          >
+            {submitting ? 'Signing in...' : 'Sign In →'}
+          </button>
+        </form>
+
+        <p className={styles.footer}>
+          Don't have an account? <Link to="/register" className={styles.link}>Sign up</Link>
+        </p>
+      </div>
+    </div>
+  );
 }

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -46,7 +46,7 @@ export default function Login() {
 
         {error && <div className={styles.errorBanner}>{error}</div>}
 
-        <form onSubmit={handleSubmit} className={styles.form} noValidate>
+        <form onSubmit={handleSubmit} className={styles.form}>
           <label className={styles.field}>
             <span className={styles.label}>Email</span>
             <div className={styles.inputWrap}>

--- a/client/src/styles/Login.module.css
+++ b/client/src/styles/Login.module.css
@@ -1,1 +1,238 @@
-/*TODO*/
+.page {
+  --bg: #0d0d12;
+  --card-bg: #1a1a22;
+  --card-border: #2a2a35;
+  --text: #e4e4e7;
+  --text-muted: #71717a;
+  --accent: #fbbf24;
+  --accent-hover: #f59e0b;
+  --input-bg: #16161e;
+  --input-border: #2a2a35;
+  --error: #ef4444;
+  --error-bg: rgba(239, 68, 68, 0.1);
+  --mono: ui-monospace, 'JetBrains Mono', Consolas, monospace;
+
+  position: fixed;
+  inset: 0;
+  overflow-y: auto;
+
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--mono);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  gap: 32px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 24px;
+  font-weight: 600;
+}
+
+.brandPrompt {
+  color: var(--accent);
+}
+
+.brandName {
+  color: var(--text);
+}
+
+.card {
+  width: 100%;
+  max-width: 540px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 40px;
+}
+
+.title {
+  font-family: var(--mono);
+  font-size: 28px;
+  font-weight: 700;
+  color: var(--text);
+  margin: 0 0 8px;
+}
+
+.subtitle {
+  color: var(--text-muted);
+  font-size: 14px;
+  margin: 0 0 32px;
+}
+
+.errorBanner {
+  background: var(--error-bg);
+  color: var(--error);
+  border: 1px solid var(--error);
+  border-radius: 6px;
+  padding: 10px 14px;
+  font-size: 13px;
+  margin-bottom: 20px;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.label {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.inputWrap {
+  display: flex;
+  align-items: center;
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 6px;
+  transition: border-color 0.15s;
+}
+
+.inputWrap:focus-within {
+  border-color: var(--accent);
+}
+
+.inputIcon {
+  padding: 0 12px;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 12px 12px 12px 0;
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 14px;
+  min-width: 0;
+}
+
+.input::placeholder {
+  color: var(--text-muted);
+}
+
+.submitBtn {
+  background: var(--accent);
+  color: #0d0d12;
+  border: none;
+  border-radius: 6px;
+  padding: 14px;
+  font-family: var(--mono);
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  margin-top: 8px;
+  transition: background 0.15s;
+}
+
+.submitBtn:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.submitBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.footer {
+  text-align: center;
+  margin: 24px 0 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.link {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.link:hover {
+  text-decoration: underline;
+}
+
+/* 태블릿 */
+@media (max-width: 768px) {
+  .page {
+    padding: 20px;
+    gap: 24px;
+  }
+
+  .card {
+    padding: 32px 28px;
+  }
+
+  .title {
+    font-size: 24px;
+  }
+
+  .subtitle {
+    margin-bottom: 24px;
+  }
+}
+
+/* 모바일 */
+@media (max-width: 480px) {
+  .page {
+    padding: 16px;
+    gap: 20px;
+    justify-content: flex-start;
+    padding-top: 48px;
+  }
+
+  .brand {
+    font-size: 20px;
+  }
+
+  .card {
+    padding: 24px 20px;
+    border-radius: 12px;
+  }
+
+  .title {
+    font-size: 22px;
+  }
+
+  .form {
+    gap: 16px;
+  }
+
+  .input {
+    padding: 14px 12px 14px 0;
+    font-size: 16px;
+  }
+
+  .inputIcon {
+    padding: 0 14px;
+  }
+
+  .submitBtn {
+    padding: 16px;
+    font-size: 16px;
+  }
+}
+
+/* 짧은 화면 (가로 모바일 등) */
+@media (max-height: 600px) {
+  .page {
+    justify-content: flex-start;
+    padding-top: 24px;
+    padding-bottom: 24px;
+  }
+}


### PR DESCRIPTION
## Changes

Implement `/login` page UI.

- `pages/Login.jsx` — email/password form with submit handling
- `styles/Login.module.css` — dark theme, monospace font, responsive (480px / 768px breakpoints)

## Behavior

- Empty field submission is blocked by the browser's `required` attribute
- On login failure, the backend `errorCode` is mapped to a Korean message and displayed above the form
  - `WRONG_PASSWORD` → "이메일 또는 비밀번호가 올바르지 않습니다."
  - `FIELD_MISSING` → "이메일과 비밀번호를 모두 입력해주세요." (defensive)
- On successful login, redirects to `/dashboard`
- "Sign up" link navigates to `/register` (Register page in a separate PR)

## Design

- Built from the desktop mockup, with mobile/tablet responsive layout
- Input `font-size: 16px` on mobile to prevent iOS Safari auto-zoom
- CSS variables scoped to `.page` inside `Login.module.css` — no global pollution

closes #48 