### PR TITLE
feat(client): implement Dashboard page

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ opensource-web-azas/
 │       ├── styles/
 │       │   ├── Auth.module.css             # Shared Login/Register styles
 │       │   ├── ConfirmModal.module.css     # ConfirmModal styles
+│       │   ├── Dashboard.module.css        # Dashboard page styles
 │       │   ├── Editor.module.css           # Editor page layout (app bar, side, terminal, resizer)
 │       │   └── LoadCodeModal.module.css    # LoadCodeModal styles
 │       ├── pages/
@@ -87,6 +88,8 @@ opensource-web-azas/
 │       └── __tests__/                      # Client unit tests (Vitest)
 │           ├── setup.js
 │           ├── AuthContext.test.jsx
+│           ├── CodeEditor.test.jsx
+│           ├── Dashboard.test.jsx
 │           ├── Login.test.jsx
 │           ├── Register.test.jsx
 │           ├── ProtectedRoute.test.jsx

--- a/client/src/__tests__/Dashboard.test.jsx
+++ b/client/src/__tests__/Dashboard.test.jsx
@@ -1,0 +1,271 @@
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, afterEach } from 'vitest';
+
+afterEach(() => cleanup());
+import Dashboard from '../pages/Dashboard';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+let mockUserData = { email: 'a@a.com', nickname: 'Val', theme: 'dark', fontSize: 14 };
+const mockLogout = vi.fn();
+const mockUpdateUser = vi.fn();
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: mockUserData, logout: mockLogout, updateUser: mockUpdateUser }),
+}));
+
+vi.mock('../utils/api', () => ({
+  apiRequest: vi.fn(),
+}));
+
+import { apiRequest } from '../utils/api';
+
+const sampleCodes = [
+  { codeId: 1, title: 'fizzbuzz.py', language: 'python', updatedAt: '2024-01-10T00:00:00Z' },
+  { codeId: 2, title: 'two-sum.js', language: 'javascript', updatedAt: '2024-01-05T00:00:00Z' },
+];
+
+function renderDashboard() {
+  return render(<Dashboard />);
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockUserData = { email: 'a@a.com', nickname: 'Val', theme: 'dark', fontSize: 14 };
+  apiRequest.mockResolvedValue({ codes: sampleCodes, total: 2 });
+  mockNavigate.mockImplementation(() => {});
+  mockLogout.mockImplementation(() => {});
+  mockUpdateUser.mockImplementation(() => {});
+});
+
+// ─── Step 1: 기본 렌더링 & 프로젝트 목록 ────────────────────────────────────
+
+describe('Dashboard — Step 1: 기본 렌더링', () => {
+  test('마운트 시 GET /code를 호출한다', async () => {
+    renderDashboard();
+    await waitFor(() => {
+      expect(apiRequest).toHaveBeenCalledWith('/code');
+    });
+  });
+
+  test('프로젝트 카드가 로드된 목록만큼 렌더된다', async () => {
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByText('fizzbuzz.py')).toBeInTheDocument();
+      expect(screen.getByText('two-sum.js')).toBeInTheDocument();
+    });
+  });
+
+  test('프로젝트가 없을 때 empty state가 렌더된다', async () => {
+    apiRequest.mockResolvedValueOnce({ codes: [], total: 0 });
+    renderDashboard();
+    await waitFor(() => {
+      expect(screen.getByText(/no projects yet/i)).toBeInTheDocument();
+    });
+  });
+
+  test('New Project 버튼이 렌더된다', () => {
+    renderDashboard();
+    expect(screen.getAllByRole('button', { name: /new project/i }).length).toBeGreaterThan(0);
+  });
+
+  test('New Project 버튼 클릭 시 /code로 이동한다', async () => {
+    renderDashboard();
+    await userEvent.click(screen.getAllByRole('button', { name: /new project/i })[0]);
+    expect(mockNavigate).toHaveBeenCalledWith('/code');
+  });
+});
+
+// ─── Step 2: 카드 클릭 & 삭제 ───────────────────────────────────────────────
+
+describe('Dashboard — Step 2: 카드 클릭 & 삭제', () => {
+  test('프로젝트 카드 클릭 시 /code/:codeId로 이동한다', async () => {
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    await userEvent.click(screen.getByText('fizzbuzz.py'));
+    expect(mockNavigate).toHaveBeenCalledWith('/code/1');
+  });
+
+  test('삭제 버튼 클릭 시 ConfirmModal이 열린다', async () => {
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    const deleteButtons = screen.getAllByRole('button', { name: /delete fizzbuzz/i });
+    await userEvent.click(deleteButtons[0]);
+    expect(screen.getByText(/this cannot be undone/i)).toBeInTheDocument();
+  });
+
+  test('ConfirmModal에서 Cancel 클릭 시 DELETE API를 호출하지 않는다', async () => {
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    const deleteButtons = screen.getAllByRole('button', { name: /delete fizzbuzz/i });
+    await userEvent.click(deleteButtons[0]);
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(apiRequest).not.toHaveBeenCalledWith('/code/1', expect.objectContaining({ method: 'DELETE' }));
+  });
+
+  test('ConfirmModal에서 Confirm 클릭 시 DELETE /code/:codeId를 호출한다', async () => {
+    apiRequest
+      .mockResolvedValueOnce({ codes: sampleCodes, total: 2 }) // GET /code
+      .mockResolvedValueOnce(null)                              // DELETE
+      .mockResolvedValueOnce({ codes: [sampleCodes[1]], total: 1 }); // GET /code refresh
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    const deleteButtons = screen.getAllByRole('button', { name: /delete fizzbuzz/i });
+    await userEvent.click(deleteButtons[0]);
+    // ConfirmModal의 confirmLabel이 "Delete"인 버튼: autoFocus 속성 확인
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(apiRequest).toHaveBeenCalledWith('/code/1', { method: 'DELETE' });
+    });
+  });
+
+  test('삭제 성공 후 목록이 갱신된다', async () => {
+    apiRequest
+      .mockResolvedValueOnce({ codes: sampleCodes, total: 2 })
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ codes: [sampleCodes[1]], total: 1 });
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    const deleteButtons = screen.getAllByRole('button', { name: /delete fizzbuzz/i });
+    await userEvent.click(deleteButtons[0]);
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    await waitFor(() => {
+      expect(screen.queryByText('fizzbuzz.py')).not.toBeInTheDocument();
+      expect(screen.getByText('two-sum.js')).toBeInTheDocument();
+    });
+  });
+});
+
+// ─── Step 3: 설정 — 테마 & 폰트 사이즈 ─────────────────────────────────────
+
+describe('Dashboard — Step 3: 설정 — 테마 & 폰트 사이즈', () => {
+  test('테마 토글 클릭 시 PUT /auth/me를 theme: light로 호출한다', async () => {
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    await userEvent.click(screen.getByRole('button', { name: /theme/i }));
+    await waitFor(() => {
+      expect(apiRequest).toHaveBeenCalledWith(
+        '/auth/me',
+        expect.objectContaining({
+          method: 'PUT',
+          body: expect.stringContaining('"theme":"light"'),
+        })
+      );
+    });
+  });
+
+  test('폰트 사이즈 + 버튼 클릭 시 PUT /auth/me를 fontSize+1로 호출한다', async () => {
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    await userEvent.click(screen.getByRole('button', { name: /increase font/i }));
+    await waitFor(() => {
+      expect(apiRequest).toHaveBeenCalledWith(
+        '/auth/me',
+        expect.objectContaining({
+          method: 'PUT',
+          body: expect.stringContaining('"fontSize":15'),
+        })
+      );
+    });
+  });
+
+  test('폰트 사이즈 − 버튼 클릭 시 PUT /auth/me를 fontSize-1로 호출한다', async () => {
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    await userEvent.click(screen.getByRole('button', { name: /decrease font/i }));
+    await waitFor(() => {
+      expect(apiRequest).toHaveBeenCalledWith(
+        '/auth/me',
+        expect.objectContaining({
+          method: 'PUT',
+          body: expect.stringContaining('"fontSize":13'),
+        })
+      );
+    });
+  });
+
+  test('폰트 사이즈가 24일 때 + 버튼이 비활성화된다', async () => {
+    mockUserData = { ...mockUserData, fontSize: 24 };
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    expect(screen.getByRole('button', { name: /increase font/i })).toBeDisabled();
+  });
+});
+
+// ─── Step 4: 설정 — 비밀번호 변경 ───────────────────────────────────────────
+
+describe('Dashboard — Step 4: 비밀번호 변경', () => {
+  test('Change 버튼 클릭 시 비밀번호 변경 폼이 열린다', async () => {
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    await userEvent.click(screen.getByRole('button', { name: /change/i }));
+    expect(screen.getByPlaceholderText(/current password/i)).toBeInTheDocument();
+  });
+
+  test('비밀번호 변경 폼 제출 시 PUT /auth/password를 호출한다', async () => {
+    apiRequest
+      .mockResolvedValueOnce({ codes: sampleCodes, total: 2 })
+      .mockResolvedValueOnce({ message: 'ok' });
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    await userEvent.click(screen.getByRole('button', { name: /change/i }));
+    await userEvent.type(screen.getByPlaceholderText(/current password/i), 'oldpass1');
+    await userEvent.type(screen.getByPlaceholderText(/new password/i), 'newpass1');
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => {
+      expect(apiRequest).toHaveBeenCalledWith(
+        '/auth/password',
+        expect.objectContaining({
+          method: 'PUT',
+          body: JSON.stringify({ oldPassword: 'oldpass1', newPassword: 'newpass1' }),
+        })
+      );
+    });
+  });
+
+  test('비밀번호 변경 성공 시 폼이 닫힌다', async () => {
+    apiRequest
+      .mockResolvedValueOnce({ codes: sampleCodes, total: 2 })
+      .mockResolvedValueOnce({ message: 'ok' });
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    await userEvent.click(screen.getByRole('button', { name: /change/i }));
+    await userEvent.type(screen.getByPlaceholderText(/current password/i), 'oldpass1');
+    await userEvent.type(screen.getByPlaceholderText(/new password/i), 'newpass1');
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText(/current password/i)).not.toBeInTheDocument();
+    });
+  });
+
+  test('WRONG_PASSWORD 오류 시 에러 메시지가 표시된다', async () => {
+    apiRequest
+      .mockResolvedValueOnce({ codes: sampleCodes, total: 2 })
+      .mockRejectedValueOnce(Object.assign(new Error(), { errorCode: 'WRONG_PASSWORD' }));
+    renderDashboard();
+    await waitFor(() => screen.getByText('fizzbuzz.py'));
+    await userEvent.click(screen.getByRole('button', { name: /change/i }));
+    await userEvent.type(screen.getByPlaceholderText(/current password/i), 'wrong');
+    await userEvent.type(screen.getByPlaceholderText(/new password/i), 'newpass1');
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/incorrect.*password/i)).toBeInTheDocument();
+    });
+  });
+});
+
+// ─── Step 5: 로그아웃 ────────────────────────────────────────────────────────
+
+describe('Dashboard — Step 5: 로그아웃', () => {
+  test('Logout 버튼 클릭 시 logout()을 호출하고 /login으로 이동한다', async () => {
+    renderDashboard();
+    await userEvent.click(screen.getByRole('button', { name: /logout/i }));
+    expect(mockLogout).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith('/login');
+  });
+});

--- a/client/src/__tests__/Dashboard.test.jsx
+++ b/client/src/__tests__/Dashboard.test.jsx
@@ -23,6 +23,10 @@ vi.mock('../utils/api', () => ({
   apiRequest: vi.fn(),
 }));
 
+vi.mock('../components/ThemeApplier', () => ({
+  default: () => null,
+}));
+
 import { apiRequest } from '../utils/api';
 
 const sampleCodes = [
@@ -69,14 +73,19 @@ describe('Dashboard — Step 1: 기본 렌더링', () => {
     });
   });
 
-  test('New Project 버튼이 렌더된다', () => {
+  test('빈 상태에서 New Project 버튼이 렌더된다', async () => {
+    apiRequest.mockResolvedValueOnce({ codes: [], total: 0 });
     renderDashboard();
-    expect(screen.getAllByRole('button', { name: /new project/i }).length).toBeGreaterThan(0);
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /new project/i })).toBeInTheDocument();
+    });
   });
 
   test('New Project 버튼 클릭 시 /code로 이동한다', async () => {
+    apiRequest.mockResolvedValueOnce({ codes: [], total: 0 });
     renderDashboard();
-    await userEvent.click(screen.getAllByRole('button', { name: /new project/i })[0]);
+    await waitFor(() => screen.getByRole('button', { name: /new project/i }));
+    await userEvent.click(screen.getByRole('button', { name: /new project/i }));
     expect(mockNavigate).toHaveBeenCalledWith('/code');
   });
 });

--- a/client/src/__tests__/Dashboard.test.jsx
+++ b/client/src/__tests__/Dashboard.test.jsx
@@ -1,8 +1,6 @@
 import { render, screen, waitFor, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { vi, afterEach } from 'vitest';
-
-afterEach(() => cleanup());
+import { vi } from 'vitest';
 import Dashboard from '../pages/Dashboard';
 
 const mockNavigate = vi.fn();
@@ -37,6 +35,8 @@ const sampleCodes = [
 function renderDashboard() {
   return render(<Dashboard />);
 }
+
+afterEach(() => cleanup());
 
 beforeEach(() => {
   vi.resetAllMocks();

--- a/client/src/contexts/AuthContext.jsx
+++ b/client/src/contexts/AuthContext.jsx
@@ -34,8 +34,12 @@ export function AuthProvider({ children }) {
     setUser(null);
   };
 
+  const updateUser = (partial) => {
+    setUser((prev) => ({ ...prev, ...partial }));
+  };
+
   return (
-    <AuthContext.Provider value={{ user, loading, login, logout }}>
+    <AuthContext.Provider value={{ user, loading, login, logout, updateUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -50,9 +50,13 @@ export default function Dashboard() {
   }
 
   async function handleDeleteConfirm() {
-    await apiRequest(`/code/${deleteTarget.codeId}`, { method: 'DELETE' });
-    setDeleteTarget(null);
-    loadCodes();
+    try {
+      await apiRequest(`/code/${deleteTarget.codeId}`, { method: 'DELETE' });
+      setDeleteTarget(null);
+      loadCodes();
+    } catch {
+      setDeleteTarget(null);
+    }
   }
 
   async function handleThemeToggle() {
@@ -183,113 +187,114 @@ export default function Dashboard() {
 
           {/* Settings panel */}
           <div className={styles.panel}>
-              <div className={styles.panelHead}>
-                <h4 className={styles.panelTitle}>Settings</h4>
+            <div className={styles.panelHead}>
+              <h4 className={styles.panelTitle}>Settings</h4>
+            </div>
+            <div className={styles.panelBody}>
+              {/* Theme */}
+              <div className={styles.setting}>
+                <div className={styles.labelBlock}>
+                  <span className={styles.settingName}>Theme</span>
+                  <span className={styles.settingDesc}>Editor appearance</span>
+                </div>
+                <button
+                  type="button"
+                  className={`${styles.toggle} ${user?.theme !== 'dark' ? styles.toggleOff : ''}`}
+                  aria-label="theme"
+                  title={user?.theme}
+                  onClick={handleThemeToggle}
+                />
               </div>
-              <div className={styles.panelBody}>
-                {/* Theme */}
-                <div className={styles.setting}>
-                  <div className={styles.labelBlock}>
-                    <span className={styles.settingName}>Theme</span>
-                    <span className={styles.settingDesc}>Editor appearance</span>
-                  </div>
+
+              {/* Font size */}
+              <div className={styles.setting}>
+                <div className={styles.labelBlock}>
+                  <span className={styles.settingName}>Font size</span>
+                  <span className={styles.settingDesc}>12–24</span>
+                </div>
+                <div className={styles.stepper}>
                   <button
                     type="button"
-                    className={`${styles.toggle} ${user?.theme !== 'dark' ? styles.toggleOff : ''}`}
-                    aria-label="theme"
-                    title={user?.theme}
-                    onClick={handleThemeToggle}
+                    aria-label="decrease font"
+                    disabled={fontSize <= 12}
+                    onClick={() => handleFontChange(-1)}
+                  >
+                    −
+                  </button>
+                  <span className={styles.stepperVal}>{fontSize}</span>
+                  <button
+                    type="button"
+                    aria-label="increase font"
+                    disabled={fontSize >= 24}
+                    onClick={() => handleFontChange(1)}
+                  >
+                    +
+                  </button>
+                </div>
+              </div>
+
+              {/* Password */}
+              <div className={styles.setting}>
+                <div className={styles.labelBlock}>
+                  <span className={styles.settingName}>Password</span>
+                  <span className={styles.settingDesc}>Change password</span>
+                </div>
+                <button
+                  type="button"
+                  aria-label="change password"
+                  className={styles.btnGhost}
+                  onClick={() => {
+                    setShowPasswordForm((v) => !v);
+                    setPasswordError('');
+                    setOldPassword('');
+                    setNewPassword('');
+                  }}
+                >
+                  Change
+                </button>
+              </div>
+
+              {showPasswordForm && (
+                <form className={styles.passwordForm} onSubmit={handlePasswordSave}>
+                  {passwordError && (
+                    <div className={styles.errorBanner}>{passwordError}</div>
+                  )}
+                  <input
+                    className={styles.input}
+                    type="password"
+                    placeholder="Current password"
+                    value={oldPassword}
+                    onChange={(e) => setOldPassword(e.target.value)}
                   />
-                </div>
-
-                {/* Font size */}
-                <div className={styles.setting}>
-                  <div className={styles.labelBlock}>
-                    <span className={styles.settingName}>Font size</span>
-                    <span className={styles.settingDesc}>12–24</span>
-                  </div>
-                  <div className={styles.stepper}>
-                    <button
-                      type="button"
-                      aria-label="decrease font"
-                      disabled={fontSize <= 12}
-                      onClick={() => handleFontChange(-1)}
-                    >
-                      −
-                    </button>
-                    <span className={styles.stepperVal}>{fontSize}</span>
-                    <button
-                      type="button"
-                      aria-label="increase font"
-                      disabled={fontSize >= 24}
-                      onClick={() => handleFontChange(1)}
-                    >
-                      +
-                    </button>
-                  </div>
-                </div>
-
-                {/* Password */}
-                <div className={styles.setting}>
-                  <div className={styles.labelBlock}>
-                    <span className={styles.settingName}>Password</span>
-                    <span className={styles.settingDesc}>Change password</span>
-                  </div>
-                  <button
-                    type="button"
-                    className={styles.btnGhost}
-                    onClick={() => {
-                      setShowPasswordForm((v) => !v);
-                      setPasswordError('');
-                      setOldPassword('');
-                      setNewPassword('');
-                    }}
-                  >
-                    Change
+                  <input
+                    className={styles.input}
+                    type="password"
+                    placeholder="New password"
+                    value={newPassword}
+                    onChange={(e) => setNewPassword(e.target.value)}
+                  />
+                  <button type="submit" className={styles.btnPrimary}>
+                    Save
                   </button>
-                </div>
+                </form>
+              )}
 
-                {showPasswordForm && (
-                  <form className={styles.passwordForm} onSubmit={handlePasswordSave}>
-                    {passwordError && (
-                      <div className={styles.errorBanner}>{passwordError}</div>
-                    )}
-                    <input
-                      className={styles.input}
-                      type="password"
-                      placeholder="Current password"
-                      value={oldPassword}
-                      onChange={(e) => setOldPassword(e.target.value)}
-                    />
-                    <input
-                      className={styles.input}
-                      type="password"
-                      placeholder="New password"
-                      value={newPassword}
-                      onChange={(e) => setNewPassword(e.target.value)}
-                    />
-                    <button type="submit" className={styles.btnPrimary}>
-                      Save
-                    </button>
-                  </form>
-                )}
-
-                {/* Logout */}
-                <div className={styles.setting}>
-                  <div className={styles.labelBlock}>
-                    <span className={styles.settingName}>Session</span>
-                    <span className={styles.settingDesc}>Sign out of this browser</span>
-                  </div>
-                  <button
-                    type="button"
-                    className={styles.btnDanger}
-                    onClick={handleLogout}
-                  >
-                    Logout
-                  </button>
+              {/* Logout */}
+              <div className={styles.setting}>
+                <div className={styles.labelBlock}>
+                  <span className={styles.settingName}>Session</span>
+                  <span className={styles.settingDesc}>Sign out of this browser</span>
                 </div>
+                <button
+                  type="button"
+                  className={styles.btnDanger}
+                  onClick={handleLogout}
+                >
+                  Logout
+                </button>
               </div>
             </div>
+          </div>
         </div>
       </div>
 

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,4 +1,311 @@
-// TODO: 구현
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { apiRequest } from '../utils/api';
+import ConfirmModal from '../components/ConfirmModal';
+import { LANG_ICONS } from '../utils/languageIcons';
+import styles from '../styles/Dashboard.module.css';
+
+function formatDate(iso) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86400000);
+  if (days === 0) return 'today';
+  if (days === 1) return '1d ago';
+  if (days < 7) return `${days}d ago`;
+  if (days < 14) return '1w ago';
+  return `${Math.floor(days / 7)}w ago`;
+}
+
 export default function Dashboard() {
-  return <div>Dashboard</div>;
+  const navigate = useNavigate();
+  const { user, logout, updateUser } = useAuth();
+
+  const [codes, setCodes] = useState([]);
+  const [deleteTarget, setDeleteTarget] = useState(null);
+  const [showPasswordForm, setShowPasswordForm] = useState(false);
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+
+  function loadCodes() {
+    apiRequest('/code').then((data) => setCodes(data?.codes ?? []));
+  }
+
+  useEffect(() => {
+    loadCodes();
+  }, []);
+
+  function handleNewProject() {
+    navigate('/code');
+  }
+
+  function handleOpenProject(codeId) {
+    navigate(`/code/${codeId}`);
+  }
+
+  function handleDeleteClick(e, code) {
+    e.stopPropagation();
+    setDeleteTarget(code);
+  }
+
+  async function handleDeleteConfirm() {
+    await apiRequest(`/code/${deleteTarget.codeId}`, { method: 'DELETE' });
+    setDeleteTarget(null);
+    loadCodes();
+  }
+
+  async function handleThemeToggle() {
+    const nextTheme = user.theme === 'dark' ? 'light' : 'dark';
+    const data = await apiRequest('/auth/me', {
+      method: 'PUT',
+      body: JSON.stringify({ theme: nextTheme }),
+    });
+    if (data?.user) updateUser(data.user);
+  }
+
+  async function handleFontChange(delta) {
+    const next = (user.fontSize || 14) + delta;
+    if (next < 12 || next > 24) return;
+    const data = await apiRequest('/auth/me', {
+      method: 'PUT',
+      body: JSON.stringify({ fontSize: next }),
+    });
+    if (data?.user) updateUser(data.user);
+  }
+
+  async function handlePasswordSave(e) {
+    e.preventDefault();
+    setPasswordError('');
+    try {
+      await apiRequest('/auth/password', {
+        method: 'PUT',
+        body: JSON.stringify({ oldPassword, newPassword }),
+      });
+      setShowPasswordForm(false);
+      setOldPassword('');
+      setNewPassword('');
+    } catch (err) {
+      if (err.errorCode === 'WRONG_PASSWORD') {
+        setPasswordError('Incorrect current password.');
+      } else {
+        setPasswordError('Failed to change password.');
+      }
+    }
+  }
+
+  function handleLogout() {
+    logout();
+    navigate('/login');
+  }
+
+  const avatarInitial = (user?.nickname || user?.email || '?')[0].toUpperCase();
+  const fontSize = user?.fontSize || 14;
+
+  return (
+    <div className={styles.page}>
+      <div className={styles.dash}>
+        {/* Top bar */}
+        <div className={styles.dashBar}>
+          <div className={styles.brand}>
+            <span className={styles.brandMark}>AJAS</span>
+            <span className={styles.brandName}>editor</span>
+          </div>
+          <div className={styles.barRight}>
+            <button
+              type="button"
+              className={styles.btnPrimary}
+              onClick={handleNewProject}
+            >
+              + New project
+            </button>
+            <div className={styles.avatar} title={user?.nickname || user?.email}>
+              {avatarInitial}
+            </div>
+          </div>
+        </div>
+
+        {/* Main grid */}
+        <div className={styles.dashGrid}>
+          {/* Projects panel */}
+          <div className={styles.panel}>
+            <div className={styles.panelHead}>
+              <h4 className={styles.panelTitle}>Projects</h4>
+              <span className={styles.count}>{codes.length} saved</span>
+            </div>
+
+            {codes.length === 0 ? (
+              <div className={styles.empty}>
+                <h5>No projects yet</h5>
+                <p>Create your first snippet — it&apos;ll show up here after the first save.</p>
+                <button
+                  type="button"
+                  className={styles.btnPrimary}
+                  onClick={handleNewProject}
+                >
+                  + New project
+                </button>
+              </div>
+            ) : (
+              <div className={styles.panelBody}>
+                <div className={styles.projectGrid}>
+                  {codes.map((code) => {
+                    const Icon = LANG_ICONS[code.language];
+                    return (
+                      <div
+                        key={code.codeId}
+                        className={styles.project}
+                        onClick={() => handleOpenProject(code.codeId)}
+                        role="button"
+                        tabIndex={0}
+                        onKeyDown={(e) => e.key === 'Enter' && handleOpenProject(code.codeId)}
+                      >
+                        <div className={styles.projectHead}>
+                          <h5 className={styles.projectTitle}>{code.title}</h5>
+                          <button
+                            type="button"
+                            className={styles.iconBtn}
+                            aria-label={`delete ${code.title}`}
+                            title="Delete"
+                            onClick={(e) => handleDeleteClick(e, code)}
+                          >
+                            ×
+                          </button>
+                        </div>
+                        <div className={styles.projectFoot}>
+                          <span className={styles.langBadge}>
+                            {Icon && <Icon size={14} />}
+                            {code.language}
+                          </span>
+                          <span>{formatDate(code.updatedAt)}</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Settings panel */}
+          <div className={styles.panel}>
+              <div className={styles.panelHead}>
+                <h4 className={styles.panelTitle}>Settings</h4>
+              </div>
+              <div className={styles.panelBody}>
+                {/* Theme */}
+                <div className={styles.setting}>
+                  <div className={styles.labelBlock}>
+                    <span className={styles.settingName}>Theme</span>
+                    <span className={styles.settingDesc}>Editor appearance</span>
+                  </div>
+                  <button
+                    type="button"
+                    className={`${styles.toggle} ${user?.theme !== 'dark' ? styles.toggleOff : ''}`}
+                    aria-label="theme"
+                    title={user?.theme}
+                    onClick={handleThemeToggle}
+                  />
+                </div>
+
+                {/* Font size */}
+                <div className={styles.setting}>
+                  <div className={styles.labelBlock}>
+                    <span className={styles.settingName}>Font size</span>
+                    <span className={styles.settingDesc}>12–24</span>
+                  </div>
+                  <div className={styles.stepper}>
+                    <button
+                      type="button"
+                      aria-label="decrease font"
+                      disabled={fontSize <= 12}
+                      onClick={() => handleFontChange(-1)}
+                    >
+                      −
+                    </button>
+                    <span className={styles.stepperVal}>{fontSize}</span>
+                    <button
+                      type="button"
+                      aria-label="increase font"
+                      disabled={fontSize >= 24}
+                      onClick={() => handleFontChange(1)}
+                    >
+                      +
+                    </button>
+                  </div>
+                </div>
+
+                {/* Password */}
+                <div className={styles.setting}>
+                  <div className={styles.labelBlock}>
+                    <span className={styles.settingName}>Password</span>
+                    <span className={styles.settingDesc}>Change password</span>
+                  </div>
+                  <button
+                    type="button"
+                    className={styles.btnGhost}
+                    onClick={() => {
+                      setShowPasswordForm((v) => !v);
+                      setPasswordError('');
+                      setOldPassword('');
+                      setNewPassword('');
+                    }}
+                  >
+                    Change
+                  </button>
+                </div>
+
+                {showPasswordForm && (
+                  <form className={styles.passwordForm} onSubmit={handlePasswordSave}>
+                    {passwordError && (
+                      <div className={styles.errorBanner}>{passwordError}</div>
+                    )}
+                    <input
+                      className={styles.input}
+                      type="password"
+                      placeholder="Current password"
+                      value={oldPassword}
+                      onChange={(e) => setOldPassword(e.target.value)}
+                    />
+                    <input
+                      className={styles.input}
+                      type="password"
+                      placeholder="New password"
+                      value={newPassword}
+                      onChange={(e) => setNewPassword(e.target.value)}
+                    />
+                    <button type="submit" className={styles.btnPrimary}>
+                      Save
+                    </button>
+                  </form>
+                )}
+
+                {/* Logout */}
+                <div className={styles.setting}>
+                  <div className={styles.labelBlock}>
+                    <span className={styles.settingName}>Session</span>
+                    <span className={styles.settingDesc}>Sign out of this browser</span>
+                  </div>
+                  <button
+                    type="button"
+                    className={styles.btnDanger}
+                    onClick={handleLogout}
+                  >
+                    Logout
+                  </button>
+                </div>
+              </div>
+            </div>
+        </div>
+      </div>
+
+      <ConfirmModal
+        open={!!deleteTarget}
+        title="Delete project"
+        message={`Delete "${deleteTarget?.title}"? This cannot be undone.`}
+        confirmLabel="Delete"
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
 }

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { apiRequest } from '../utils/api';
 import ConfirmModal from '../components/ConfirmModal';
+import ThemeApplier from '../components/ThemeApplier';
 import { LANG_ICONS } from '../utils/languageIcons';
 import styles from '../styles/Dashboard.module.css';
 
@@ -103,6 +104,7 @@ export default function Dashboard() {
 
   return (
     <div className={styles.page}>
+      <ThemeApplier theme={user?.theme} />
       <div className={styles.dash}>
         {/* Top bar */}
         <div className={styles.dashBar}>
@@ -111,13 +113,6 @@ export default function Dashboard() {
             <span className={styles.brandName}>editor</span>
           </div>
           <div className={styles.barRight}>
-            <button
-              type="button"
-              className={styles.btnPrimary}
-              onClick={handleNewProject}
-            >
-              + New project
-            </button>
             <div className={styles.avatar} title={user?.nickname || user?.email}>
               {avatarInitial}
             </div>

--- a/client/src/styles/Dashboard.module.css
+++ b/client/src/styles/Dashboard.module.css
@@ -1,0 +1,419 @@
+.page {
+  position: fixed;
+  inset: 0;
+  overflow-y: auto;
+  background: var(--bg);
+  padding: 32px 24px;
+}
+
+.dash {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* Top bar */
+.dashBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 10px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.brandMark { color: var(--text-muted); }
+.brandName  { color: var(--text); }
+
+.barRight {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--text);
+  color: var(--card-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+/* Layout */
+.dashGrid {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  gap: 24px;
+  align-items: start;
+}
+
+.dashSingle {
+  display: flex;
+  flex-direction: column;
+}
+
+/* Panel */
+.panel {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.panelHead {
+  padding: 14px 18px;
+  border-bottom: 1px solid var(--divider);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.panelTitle {
+  font-size: 13px;
+  font-weight: 500;
+  margin: 0;
+  letter-spacing: 0.02em;
+}
+
+.count {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.panelBody {
+  padding: 18px;
+}
+
+/* Project grid */
+.projectGrid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+}
+
+.project {
+  border: 1px solid var(--card-border);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  background: var(--card-bg);
+  cursor: pointer;
+  outline: none;
+}
+
+.project:hover {
+  background: var(--hover);
+}
+
+.project:focus-visible {
+  box-shadow: 0 0 0 2px var(--input-border-focus);
+}
+
+.projectHead {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.projectTitle {
+  font-size: 14px;
+  font-weight: 500;
+  margin: 0;
+  letter-spacing: -0.005em;
+  word-break: break-all;
+}
+
+.iconBtn {
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-subtle);
+  font-family: var(--mono);
+  font-size: 16px;
+  cursor: pointer;
+  flex-shrink: 0;
+  line-height: 1;
+  padding: 0;
+}
+
+.iconBtn:hover {
+  background: var(--hover);
+  color: var(--error);
+}
+
+.projectFoot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+.langBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mono);
+  font-size: 11px;
+  padding: 3px 7px;
+  border-radius: 4px;
+  background: var(--bg);
+  border: 1px solid var(--divider);
+  color: var(--text);
+}
+
+/* Empty state */
+.empty {
+  text-align: center;
+  padding: 56px 24px;
+  color: var(--text-muted);
+}
+
+.empty h5 {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--text);
+  margin: 0 0 6px;
+}
+
+.empty p {
+  font-size: 13px;
+  margin: 0 0 18px;
+}
+
+/* Settings */
+.setting {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--divider);
+}
+
+.setting:last-of-type {
+  border-bottom: none;
+}
+
+.labelBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.settingName {
+  font-size: 13px;
+  color: var(--text);
+}
+
+.settingDesc {
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* Toggle */
+.toggle {
+  width: 36px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--text);
+  border: none;
+  position: relative;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.toggle::after {
+  content: '';
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  background: #fff;
+  border-radius: 50%;
+  top: 3px;
+  right: 3px;
+  transition: right 0.15s, left 0.15s;
+}
+
+.toggleOff {
+  background: var(--input-border);
+}
+
+.toggleOff::after {
+  right: auto;
+  left: 3px;
+}
+
+/* Stepper */
+.stepper {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--input-border);
+  border-radius: 6px;
+  padding: 2px;
+}
+
+.stepper button {
+  width: 22px;
+  height: 22px;
+  border: none;
+  background: transparent;
+  color: var(--text-muted);
+  font-family: var(--mono);
+  font-size: 14px;
+  cursor: pointer;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
+}
+
+.stepper button:hover:not(:disabled) {
+  background: var(--hover);
+}
+
+.stepper button:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+.stepperVal {
+  font-family: var(--mono);
+  font-size: 12px;
+  min-width: 24px;
+  text-align: center;
+}
+
+/* Password form */
+.passwordForm {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 0 4px;
+}
+
+.input {
+  background: var(--input-bg);
+  border: 1px solid var(--input-border);
+  border-radius: 6px;
+  padding: 9px 12px;
+  font-family: var(--sans);
+  font-size: 13px;
+  color: var(--text);
+  outline: none;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.input:focus {
+  border-color: var(--input-border-focus);
+}
+
+.errorBanner {
+  background: var(--error-bg);
+  color: var(--error);
+  border: 1px solid var(--error-border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 12px;
+}
+
+/* Buttons */
+.btnPrimary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--btn-bg);
+  color: var(--btn-text);
+  border: 1px solid var(--btn-bg);
+  border-radius: 6px;
+  padding: 7px 11px;
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.btnPrimary:hover {
+  opacity: 0.85;
+}
+
+.btnGhost {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--btn-ghost-border);
+  border-radius: 6px;
+  padding: 7px 11px;
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.btnGhost:hover {
+  background: var(--hover);
+}
+
+.btnDanger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  color: var(--error);
+  border: 1px solid var(--error-border);
+  border-radius: 6px;
+  padding: 7px 11px;
+  font-family: var(--sans);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.btnDanger:hover {
+  background: var(--error-bg);
+}
+
+@media (max-width: 768px) {
+  .dashGrid {
+    grid-template-columns: 1fr;
+  }
+
+  .projectGrid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- Implement Dashboard page with saved project list (card click -> /code/:codeId, delete with ConfirmModal)
- Add settings panel: theme toggle, font size stepper, password change, logout
- Add updateUser to AuthContext for partial user state updates
- Fix missing ThemeApplier that prevented theme from updating without page reload
- Remove redundant top-bar New Project button (kept only in empty state)

## Test plan
- [x] Dashboard loads and displays saved project cards
- [x] Clicking a card navigates to /code/:codeId
- [x] Delete button opens ConfirmModal; confirm triggers DELETE API and refreshes list
- [x] Theme toggle calls PUT /auth/me and updates theme immediately
- [x] Font size +/- calls PUT /auth/me; + disabled at fontSize 24
- [x] Password change form opens, submits PUT /auth/password, closes on success
- [x] WRONG_PASSWORD error shows inline error message
- [x] Logout calls logout() and navigates to /login
- [x] All 19 client tests pass

closes #80