### PR TITLE
feat(client): implement NotFound page

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ opensource-web-azas/
 │       │   ├── Dashboard.module.css        # Dashboard page styles
 │       │   ├── Editor.module.css           # Editor page layout (app bar, side, terminal, resizer)
 │       │   ├── Landing.module.css          # Landing page styles (sticky hero, scroll steps, nav)
-│       │   └── LoadCodeModal.module.css    # LoadCodeModal styles
+│       │   ├── LoadCodeModal.module.css    # LoadCodeModal styles
+│       │   └── NotFound.module.css         # 404 page styles
 │       ├── pages/
 │       │   ├── CodeEditor.jsx              # Editor page
 │       │   ├── Dashboard.jsx               # Saved code list
@@ -95,6 +96,7 @@ opensource-web-azas/
 │           ├── Dashboard.test.jsx
 │           ├── Landing.test.jsx
 │           ├── Login.test.jsx
+│           ├── NotFound.test.jsx
 │           ├── Register.test.jsx
 │           ├── ProtectedRoute.test.jsx
 │           └── PublicRoute.test.jsx

--- a/client/src/__tests__/NotFound.test.jsx
+++ b/client/src/__tests__/NotFound.test.jsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+import NotFound from '../pages/NotFound';
+
+vi.mock('react-router-dom', () => ({
+  Link: ({ children, to }) => <a href={to}>{children}</a>,
+}));
+
+function renderNotFound() {
+  return render(<NotFound />);
+}
+
+describe('NotFound', () => {
+  test('renders 404 code number', () => {
+    renderNotFound();
+    expect(screen.getByText('404')).toBeInTheDocument();
+  });
+
+  test('renders PAGE NOT FOUND label', () => {
+    renderNotFound();
+    expect(screen.getByText(/page not found/i)).toBeInTheDocument();
+  });
+
+  test('renders heading', () => {
+    renderNotFound();
+    expect(
+      screen.getByRole('heading', { name: /this route doesn't exist/i }),
+    ).toBeInTheDocument();
+  });
+
+  test('Go home link points to /', () => {
+    renderNotFound();
+    expect(screen.getByRole('link', { name: /go home/i })).toHaveAttribute('href', '/');
+  });
+
+  test('Dashboard link points to /dashboard', () => {
+    renderNotFound();
+    expect(screen.getByRole('link', { name: /dashboard/i })).toHaveAttribute(
+      'href',
+      '/dashboard',
+    );
+  });
+});

--- a/client/src/pages/NotFound.jsx
+++ b/client/src/pages/NotFound.jsx
@@ -1,4 +1,21 @@
-// TODO: 구현
+import { Link } from 'react-router-dom';
+import styles from '../styles/NotFound.module.css';
+
 export default function NotFound() {
-  return <div>NotFound</div>;
+  return (
+    <div className={styles.page}>
+      <div className={styles.card}>
+        <p className={styles.codeNum}>404</p>
+        <p className={styles.codeSub}>PAGE NOT FOUND</p>
+        <h1 className={styles.title}>This route doesn't exist</h1>
+        <p className={styles.desc}>
+          The URL you opened isn't part of this app. Head back to something familiar.
+        </p>
+        <div className={styles.actions}>
+          <Link to="/" className={styles.btn}>Go home</Link>
+          <Link to="/dashboard" className={styles.btnGhost}>Dashboard</Link>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/client/src/styles/NotFound.module.css
+++ b/client/src/styles/NotFound.module.css
@@ -1,0 +1,93 @@
+.page {
+  position: fixed;
+  inset: 0;
+  overflow-y: auto;
+  background: var(--bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.card {
+  width: 100%;
+  max-width: 480px;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  text-align: center;
+  padding: 80px 24px;
+}
+
+.codeNum {
+  font-family: var(--mono);
+  font-size: 96px;
+  font-weight: 400;
+  letter-spacing: -0.02em;
+  margin: 0;
+  line-height: 1;
+  color: var(--text);
+}
+
+.codeSub {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--text-muted);
+  margin: 12px 0 4px;
+  letter-spacing: 0.08em;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 500;
+  margin: 16px 0 8px;
+  letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+.desc {
+  font-size: 14px;
+  color: var(--text-muted);
+  margin: 0 0 24px;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  background: var(--btn-bg);
+  color: var(--btn-text);
+  border: none;
+  border-radius: 6px;
+  padding: 10px 18px;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: opacity 0.15s;
+}
+
+.btn:hover {
+  opacity: 0.85;
+}
+
+.btnGhost {
+  background: transparent;
+  color: var(--text);
+  border: 1px solid var(--input-border);
+  border-radius: 6px;
+  padding: 10px 18px;
+  font-family: var(--sans);
+  font-size: 14px;
+  font-weight: 500;
+  text-decoration: none;
+  transition: background 0.15s;
+}
+
+.btnGhost:hover {
+  background: var(--hover);
+}


### PR DESCRIPTION
## Summary
- Replace the NotFound stub with the design.html spec (404 / sub / heading / desc / two action links)
- Add NotFound.module.css mapped to existing global design tokens
- Add Vitest coverage (5 tests, TDD)
- Update README file tree

## Test plan
- [x] npm run lint (0 errors)
- [x] npm test (90/90 pass, 5 new)
- [x] npm run build

closes #85