### PR TITLE
refactor(client): extract shared Button component

### DIFF
--- a/client/src/components/Button.jsx
+++ b/client/src/components/Button.jsx
@@ -1,0 +1,31 @@
+import styles from '../styles/Button.module.css';
+
+// Shared button. Renders as <button> by default, or any element via `as`
+// (e.g. react-router Link). variant/size/fullWidth map to Button.module.css.
+export default function Button({
+  as: Component = 'button',
+  variant = 'primary',
+  size = 'sm',
+  fullWidth = false,
+  className = '',
+  children,
+  ...rest
+}) {
+  const classes = [
+    styles.btn,
+    styles[variant],
+    styles[size],
+    fullWidth ? styles.fullWidth : '',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  const extra = Component === 'button' ? { type: rest.type ?? 'button' } : {};
+
+  return (
+    <Component className={classes} {...extra} {...rest}>
+      {children}
+    </Component>
+  );
+}

--- a/client/src/components/ConfirmModal.jsx
+++ b/client/src/components/ConfirmModal.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import Button from './Button';
 import styles from '../styles/ConfirmModal.module.css';
 
 // 위험·되돌릴 수 없는 액션 직전에 한 번 더 확인받는 모달
@@ -29,21 +30,12 @@ export default function ConfirmModal({
         {title && <h3 className={styles.title}>{title}</h3>}
         {message && <p className={styles.message}>{message}</p>}
         <div className={styles.actions}>
-          <button
-            type="button"
-            className={`${styles.btn} ${styles.btnCancel}`}
-            onClick={onCancel}
-          >
+          <Button variant="ghost" size="modal" onClick={onCancel}>
             {cancelLabel}
-          </button>
-          <button
-            type="button"
-            className={`${styles.btn} ${styles.btnConfirm}`}
-            onClick={onConfirm}
-            autoFocus
-          >
+          </Button>
+          <Button variant="primary" size="modal" onClick={onConfirm} autoFocus>
             {confirmLabel}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/client/src/components/Toolbar.jsx
+++ b/client/src/components/Toolbar.jsx
@@ -1,3 +1,4 @@
+import Button from './Button';
 import styles from '../styles/Editor.module.css';
 
 // 상단 앱바. 브랜드(랜딩 이동)·파일명·대시보드·로드·저장·실행 컨트롤
@@ -34,18 +35,18 @@ export default function Toolbar({
         </div>
       </div>
       <div className={styles.appBarRight}>
-        <button type="button" className={styles.btnGhost} onClick={onDashboard}>
+        <Button variant="ghost" onClick={onDashboard}>
           Dashboard
-        </button>
-        <button type="button" className={styles.btnGhost} onClick={onLoad}>
+        </Button>
+        <Button variant="ghost" onClick={onLoad}>
           Load
-        </button>
-        <button type="button" className={styles.btnGhost} onClick={onSave}>
+        </Button>
+        <Button variant="ghost" onClick={onSave}>
           Save
-        </button>
-        <button type="button" className={styles.btnPrimary} onClick={onRun} disabled={running}>
+        </Button>
+        <Button variant="primary" onClick={onRun} disabled={running}>
           {running ? 'Running…' : '▶  Run'}
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -9,6 +9,7 @@
   --input-border-focus: #111110;
   --btn-bg: #111110;
   --btn-text: #ffffff;
+  --btn-ghost-border: rgba(0, 0, 0, 0.16);
   --error: #c0392b;
   --error-bg: #fef2f2;
   --error-border: rgba(192, 57, 43, 0.2);
@@ -49,6 +50,7 @@
     --input-border-focus: #e8e8e6;
     --btn-bg: #e8e8e6;
     --btn-text: #111110;
+    --btn-ghost-border: rgba(255, 255, 255, 0.16);
     --divider: rgba(255, 255, 255, 0.07);
     --hover: rgba(255, 255, 255, 0.04);
   }
@@ -65,6 +67,7 @@
   --input-border-focus: #111110;
   --btn-bg: #111110;
   --btn-text: #ffffff;
+  --btn-ghost-border: rgba(0, 0, 0, 0.16);
   --divider: rgba(0, 0, 0, 0.06);
   --hover: rgba(0, 0, 0, 0.03);
 }

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -4,6 +4,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { apiRequest } from '../utils/api';
 import ConfirmModal from '../components/ConfirmModal';
 import ThemeApplier from '../components/ThemeApplier';
+import Button from '../components/Button';
 import { LANG_ICONS } from '../utils/languageIcons';
 import styles from '../styles/Dashboard.module.css';
 
@@ -136,13 +137,9 @@ export default function Dashboard() {
               <div className={styles.empty}>
                 <h5>No projects yet</h5>
                 <p>Create your first snippet — it&apos;ll show up here after the first save.</p>
-                <button
-                  type="button"
-                  className={styles.btnPrimary}
-                  onClick={handleNewProject}
-                >
+                <Button variant="primary" onClick={handleNewProject}>
                   + New project
-                </button>
+                </Button>
               </div>
             ) : (
               <div className={styles.panelBody}>
@@ -239,10 +236,9 @@ export default function Dashboard() {
                   <span className={styles.settingName}>Password</span>
                   <span className={styles.settingDesc}>Change password</span>
                 </div>
-                <button
-                  type="button"
+                <Button
+                  variant="ghost"
                   aria-label="change password"
-                  className={styles.btnGhost}
                   onClick={() => {
                     setShowPasswordForm((v) => !v);
                     setPasswordError('');
@@ -251,7 +247,7 @@ export default function Dashboard() {
                   }}
                 >
                   Change
-                </button>
+                </Button>
               </div>
 
               {showPasswordForm && (
@@ -273,9 +269,9 @@ export default function Dashboard() {
                     value={newPassword}
                     onChange={(e) => setNewPassword(e.target.value)}
                   />
-                  <button type="submit" className={styles.btnPrimary}>
+                  <Button type="submit" variant="primary">
                     Save
-                  </button>
+                  </Button>
                 </form>
               )}
 
@@ -285,13 +281,9 @@ export default function Dashboard() {
                   <span className={styles.settingName}>Session</span>
                   <span className={styles.settingDesc}>Sign out of this browser</span>
                 </div>
-                <button
-                  type="button"
-                  className={styles.btnDanger}
-                  onClick={handleLogout}
-                >
+                <Button variant="danger" onClick={handleLogout}>
                   Logout
-                </button>
+                </Button>
               </div>
             </div>
           </div>

--- a/client/src/pages/Landing.jsx
+++ b/client/src/pages/Landing.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import heroBg from '../assets/landing_image.png';
+import Button from '../components/Button';
 import s from '../styles/Landing.module.css';
 
 export default function Landing() {
@@ -57,8 +58,8 @@ export default function Landing() {
               <span className={s.brandName}>editor</span>
             </Link>
             <div className={s.navActions}>
-              <Link to="/login" className={s.btnGhost}>Sign in</Link>
-              <Link to="/register" className={s.btnPrimary}>Get started</Link>
+              <Button as={Link} to="/login" variant="ghost">Sign in</Button>
+              <Button as={Link} to="/register" variant="primary">Get started</Button>
             </div>
           </nav>
 
@@ -69,8 +70,8 @@ export default function Landing() {
               <p className={s.eyebrow}>Ready to start?</p>
               <h1 className={s.heroTitle}>Open the editor.<br /><span className={s.accent}>// no setup required.</span></h1>
               <div className={s.ctaActions}>
-                <Link to="/code" className={s.btnPrimaryLg}>Open editor →</Link>
-                <Link to="/register" className={s.btnGhostLg}>Create account</Link>
+                <Button as={Link} to="/code" variant="primary" size="md">Open editor →</Button>
+                <Button as={Link} to="/register" variant="ghost" size="md">Create account</Button>
               </div>
             </div>
 

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import Button from '../components/Button';
 import styles from '../styles/Auth.module.css';
 
 const ERROR_MESSAGES = {
@@ -75,13 +76,16 @@ export default function Login() {
             />
           </label>
 
-          <button
+          <Button
             type="submit"
+            variant="primary"
+            size="submit"
+            fullWidth
             disabled={submitting}
             className={styles.submitBtn}
           >
             {submitting ? 'Signing in...' : 'Sign in'}
-          </button>
+          </Button>
         </form>
 
         <p className={styles.footer}>

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { apiRequest } from '../utils/api';
+import Button from '../components/Button';
 import styles from '../styles/Auth.module.css';
  
 const ERROR_MESSAGES = {
@@ -113,13 +114,16 @@ export default function Register() {
             />
           </label>
  
-          <button
+          <Button
             type="submit"
+            variant="primary"
+            size="submit"
+            fullWidth
             disabled={submitting}
             className={styles.submitBtn}
           >
             {submitting ? 'Creating account...' : 'Sign up'}
-          </button>
+          </Button>
         </form>
  
         <p className={styles.footer}>

--- a/client/src/styles/Auth.module.css
+++ b/client/src/styles/Auth.module.css
@@ -108,27 +108,7 @@
 }
 
 .submitBtn {
-  background: var(--btn-bg);
-  color: var(--btn-text);
-  border: none;
-  border-radius: 6px;
-  padding: 11px;
-  font-family: var(--sans);
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
   margin-top: 4px;
-  transition: opacity 0.15s;
-  width: 100%;
-}
-
-.submitBtn:hover:not(:disabled) {
-  opacity: 0.85;
-}
-
-.submitBtn:disabled {
-  opacity: 0.45;
-  cursor: not-allowed;
 }
 
 .footer {

--- a/client/src/styles/Button.module.css
+++ b/client/src/styles/Button.module.css
@@ -1,0 +1,74 @@
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  font-family: var(--sans);
+  font-weight: 500;
+  cursor: pointer;
+  line-height: 1;
+  text-decoration: none;
+  border: 1px solid transparent;
+  transition: opacity 0.15s, background 0.15s, border-color 0.15s;
+}
+
+/* Variants */
+.primary {
+  background: var(--btn-bg);
+  color: var(--btn-text);
+  border-color: var(--btn-bg);
+}
+
+.primary:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.ghost {
+  background: transparent;
+  color: var(--text);
+  border-color: var(--btn-ghost-border);
+}
+
+.ghost:hover:not(:disabled) {
+  background: var(--hover);
+}
+
+.danger {
+  background: transparent;
+  color: var(--error);
+  border-color: var(--error-border);
+}
+
+.danger:hover:not(:disabled) {
+  background: var(--error-bg);
+}
+
+/* Sizes */
+.sm {
+  padding: 7px 11px;
+  font-size: 12px;
+}
+
+.md {
+  padding: 12px 22px;
+  font-size: 14px;
+}
+
+.modal {
+  padding: 8px 14px;
+  font-size: 13px;
+}
+
+.submit {
+  padding: 11px;
+  font-size: 14px;
+}
+
+.fullWidth {
+  width: 100%;
+}
+
+.btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}

--- a/client/src/styles/ConfirmModal.module.css
+++ b/client/src/styles/ConfirmModal.module.css
@@ -39,36 +39,3 @@
   gap: 8px;
 }
 
-.btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 6px;
-  font-family: var(--sans);
-  font-size: 13px;
-  font-weight: 500;
-  padding: 8px 14px;
-  cursor: pointer;
-  line-height: 1;
-  border: 1px solid transparent;
-}
-
-.btnCancel {
-  background: transparent;
-  color: var(--text);
-  border-color: var(--input-border);
-}
-
-.btnCancel:hover {
-  background: var(--hover);
-}
-
-.btnConfirm {
-  background: var(--btn-bg);
-  color: var(--btn-text);
-  border-color: var(--btn-bg);
-}
-
-.btnConfirm:hover {
-  opacity: 0.9;
-}

--- a/client/src/styles/Dashboard.module.css
+++ b/client/src/styles/Dashboard.module.css
@@ -347,67 +347,6 @@
   font-size: 12px;
 }
 
-/* Buttons */
-.btnPrimary {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--btn-bg);
-  color: var(--btn-text);
-  border: 1px solid var(--btn-bg);
-  border-radius: 6px;
-  padding: 7px 11px;
-  font-family: var(--sans);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  line-height: 1;
-}
-
-.btnPrimary:hover {
-  opacity: 0.85;
-}
-
-.btnGhost {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  color: var(--text);
-  border: 1px solid var(--btn-ghost-border);
-  border-radius: 6px;
-  padding: 7px 11px;
-  font-family: var(--sans);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  line-height: 1;
-}
-
-.btnGhost:hover {
-  background: var(--hover);
-}
-
-.btnDanger {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  color: var(--error);
-  border: 1px solid var(--error-border);
-  border-radius: 6px;
-  padding: 7px 11px;
-  font-family: var(--sans);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  line-height: 1;
-}
-
-.btnDanger:hover {
-  background: var(--error-bg);
-}
-
 @media (max-width: 768px) {
   .dashGrid {
     grid-template-columns: 1fr;

--- a/client/src/styles/Editor.module.css
+++ b/client/src/styles/Editor.module.css
@@ -104,46 +104,6 @@
   flex-shrink: 0;
 }
 
-.btnGhost,
-.btnPrimary {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 6px;
-  font-family: var(--sans);
-  font-size: 12px;
-  font-weight: 500;
-  padding: 7px 12px;
-  cursor: pointer;
-  line-height: 1;
-  border: 1px solid transparent;
-}
-
-.btnGhost {
-  background: transparent;
-  color: var(--text);
-  border-color: var(--input-border);
-}
-
-.btnGhost:hover {
-  background: var(--hover);
-}
-
-.btnPrimary {
-  background: var(--btn-bg);
-  color: var(--btn-text);
-  border-color: var(--btn-bg);
-}
-
-.btnPrimary:hover:not(:disabled) {
-  opacity: 0.9;
-}
-
-.btnPrimary:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
-
 .body {
   flex: 1;
   display: flex;

--- a/client/src/styles/Landing.module.css
+++ b/client/src/styles/Landing.module.css
@@ -82,48 +82,6 @@
   gap: 8px;
 }
 
-.btnGhost {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  color: var(--text);
-  border: 1px solid var(--btn-ghost-border, rgba(0, 0, 0, 0.16));
-  border-radius: 6px;
-  padding: 7px 11px;
-  font-family: var(--sans);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  text-decoration: none;
-  line-height: 1;
-}
-
-.btnGhost:hover {
-  background: var(--hover);
-}
-
-.btnPrimary {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--btn-bg);
-  color: var(--btn-text);
-  border: 1px solid var(--btn-bg);
-  border-radius: 6px;
-  padding: 7px 11px;
-  font-family: var(--sans);
-  font-size: 12px;
-  font-weight: 500;
-  cursor: pointer;
-  text-decoration: none;
-  line-height: 1;
-}
-
-.btnPrimary:hover {
-  opacity: 0.85;
-}
-
 /* ===== Hero content (scroll steps) ===== */
 .heroContent {
   position: absolute;
@@ -199,49 +157,6 @@
   justify-content: center;
   margin-top: 32px;
 }
-
-.btnPrimaryLg {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--btn-bg);
-  color: var(--btn-text);
-  border: 1px solid var(--btn-bg);
-  border-radius: 6px;
-  padding: 12px 22px;
-  font-family: var(--sans);
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  text-decoration: none;
-  line-height: 1;
-}
-
-.btnPrimaryLg:hover {
-  opacity: 0.85;
-}
-
-.btnGhostLg {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: transparent;
-  color: var(--text);
-  border: 1px solid var(--btn-ghost-border, rgba(0, 0, 0, 0.16));
-  border-radius: 6px;
-  padding: 12px 22px;
-  font-family: var(--sans);
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  text-decoration: none;
-  line-height: 1;
-}
-
-.btnGhostLg:hover {
-  background: var(--hover);
-}
-
 
 /* ===== Step 3: features ===== */
 .featuresGrid {


### PR DESCRIPTION
## Summary
- Consolidate primary/ghost/danger buttons scattered across 5 CSS Modules into a single \components/Button.jsx\ + \styles/Button.module.css- \Button\ supports variant (primary/ghost/danger), size (sm/md/modal/submit), fullWidth, and renders as button or react-router Link via \s- Add missing \--btn-ghost-border\ token to index.css (was undefined; Dashboard ghost border was broken, Landing relied on inline fallback)
- Remove orphaned button CSS from Auth/Editor/Dashboard/ConfirmModal/Landing modules (net -137 lines)

## Test plan
- [x] npm run lint — 0 errors
- [x] npm test — 90 passed (no regression)
- [x] npm run build — success, CSS 20.50 -> 19.12 kB
- [ ] Manual: verify buttons render identically in light/dark across Landing, Login, Dashboard, CodeEditor

closes #87