### PR TITLE
refactor(client): extract shared date/error/escape utilities

### DIFF
--- a/client/src/components/ConfirmModal.jsx
+++ b/client/src/components/ConfirmModal.jsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
 import Button from './Button';
+import useEscapeKey from '../hooks/useEscapeKey';
 import styles from '../styles/ConfirmModal.module.css';
 
 // 위험·되돌릴 수 없는 액션 직전에 한 번 더 확인받는 모달
@@ -13,14 +13,7 @@ export default function ConfirmModal({
   onCancel,
 }) {
   // ESC로 취소
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e) => {
-      if (e.key === 'Escape') onCancel?.();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [open, onCancel]);
+  useEscapeKey(open, onCancel);
 
   if (!open) return null;
 

--- a/client/src/components/LoadCodeModal.jsx
+++ b/client/src/components/LoadCodeModal.jsx
@@ -1,14 +1,8 @@
 import { useEffect, useState } from 'react';
 import { apiRequest } from '../utils/api';
+import { formatAbsolute } from '../utils/date';
+import useEscapeKey from '../hooks/useEscapeKey';
 import styles from '../styles/LoadCodeModal.module.css';
-
-// 날짜 포맷. YYYY-MM-DD HH:MM
-const formatDate = (iso) => {
-  if (!iso) return '';
-  const d = new Date(iso);
-  const pad = (n) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
-};
 
 // 저장된 코드 목록 모달. 선택 시 onSelect(codeId) 호출
 export default function LoadCodeModal({ open, onSelect, onClose }) {
@@ -45,14 +39,7 @@ export default function LoadCodeModal({ open, onSelect, onClose }) {
   }, [open]);
 
   // ESC로 닫기
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e) => {
-      if (e.key === 'Escape') onClose?.();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [open, onClose]);
+  useEscapeKey(open, onClose);
 
   if (!open) return null;
 
@@ -84,7 +71,7 @@ export default function LoadCodeModal({ open, onSelect, onClose }) {
             >
               <div className={styles.rowMain}>
                 <span className={styles.rowTitle}>{c.title}</span>
-                <span className={styles.rowMeta}>{formatDate(c.updatedAt)}</span>
+                <span className={styles.rowMeta}>{formatAbsolute(c.updatedAt)}</span>
               </div>
               <span className={styles.rowLang}>{c.language}</span>
             </button>

--- a/client/src/hooks/useCodeExecution.js
+++ b/client/src/hooks/useCodeExecution.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { apiRequest } from '../utils/api';
+import { toUserMessage } from '../utils/errorMessage';
 
 const ERROR_MESSAGES = {
   LANGUAGE_MISSING: 'Language is missing.',
@@ -25,8 +26,7 @@ export default function useCodeExecution() {
       });
       setResult(data);
     } catch (err) {
-      const msg = ERROR_MESSAGES[err.errorCode] || err.message || 'Execution failed.';
-      setError(msg);
+      setError(toUserMessage(err, ERROR_MESSAGES, 'Execution failed.'));
       setResult(null);
     } finally {
       setLoading(false);

--- a/client/src/hooks/useEscapeKey.js
+++ b/client/src/hooks/useEscapeKey.js
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+
+// Call `handler` when Escape is pressed, while `active` is true.
+export default function useEscapeKey(active, handler) {
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (e) => {
+      if (e.key === 'Escape') handler?.();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [active, handler]);
+}

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -7,17 +7,8 @@ import ThemeApplier from '../components/ThemeApplier';
 import Button from '../components/Button';
 import Brand from '../components/Brand';
 import { LANG_ICONS } from '../utils/languageIcons';
+import { formatRelative } from '../utils/date';
 import styles from '../styles/Dashboard.module.css';
-
-function formatDate(iso) {
-  const diff = Date.now() - new Date(iso).getTime();
-  const days = Math.floor(diff / 86400000);
-  if (days === 0) return 'today';
-  if (days === 1) return '1d ago';
-  if (days < 7) return `${days}d ago`;
-  if (days < 14) return '1w ago';
-  return `${Math.floor(days / 7)}w ago`;
-}
 
 export default function Dashboard() {
   const navigate = useNavigate();
@@ -170,7 +161,7 @@ export default function Dashboard() {
                             {Icon && <Icon size={14} />}
                             {code.language}
                           </span>
-                          <span>{formatDate(code.updatedAt)}</span>
+                          <span>{formatRelative(code.updatedAt)}</span>
                         </div>
                       </div>
                     );

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import Button from '../components/Button';
 import Brand from '../components/Brand';
+import { toUserMessage } from '../utils/errorMessage';
 import styles from '../styles/Auth.module.css';
 
 const ERROR_MESSAGES = {
@@ -28,8 +29,7 @@ export default function Login() {
       await login(email, password);
       navigate('/dashboard');
     } catch (err) {
-      const msg = ERROR_MESSAGES[err.errorCode] || err.message || 'Login failed.';
-      setError(msg);
+      setError(toUserMessage(err, ERROR_MESSAGES, 'Login failed.'));
     } finally {
       setSubmitting(false);
     }

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { apiRequest } from '../utils/api';
 import Button from '../components/Button';
 import Brand from '../components/Brand';
+import { toUserMessage } from '../utils/errorMessage';
 import styles from '../styles/Auth.module.css';
  
 const ERROR_MESSAGES = {
@@ -40,8 +41,7 @@ export default function Register() {
       });
       navigate('/login');
     } catch (err) {
-      const msg = ERROR_MESSAGES[err.errorCode] || err.message || 'Registration failed.';
-      setError(msg);
+      setError(toUserMessage(err, ERROR_MESSAGES, 'Registration failed.'));
     } finally {
       setSubmitting(false);
     }

--- a/client/src/utils/date.js
+++ b/client/src/utils/date.js
@@ -1,0 +1,18 @@
+// Relative time, e.g. "today", "1d ago", "2w ago".
+export function formatRelative(iso) {
+  const diff = Date.now() - new Date(iso).getTime();
+  const days = Math.floor(diff / 86400000);
+  if (days === 0) return 'today';
+  if (days === 1) return '1d ago';
+  if (days < 7) return `${days}d ago`;
+  if (days < 14) return '1w ago';
+  return `${Math.floor(days / 7)}w ago`;
+}
+
+// Absolute timestamp, e.g. "2026-06-04 14:30".
+export function formatAbsolute(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}

--- a/client/src/utils/errorMessage.js
+++ b/client/src/utils/errorMessage.js
@@ -1,0 +1,5 @@
+// Map an apiRequest error to a user-facing message: prefer a known errorCode
+// from the table, then the server message, then the fallback.
+export function toUserMessage(err, table, fallback) {
+  return table[err.errorCode] || err.message || fallback;
+}


### PR DESCRIPTION
## Summary
- Extract duplicated logic into shared modules (behavior unchanged):
  - utils/date.js — formatRelative (Dashboard) + formatAbsolute (LoadCodeModal), was two separate formatDate
  - utils/errorMessage.js — toUserMessage(err, table, fallback), replaces the 3x duplicated mapping in Login/Register/useCodeExecution
  - hooks/useEscapeKey.js — shared ESC-to-close handler for ConfirmModal and LoadCodeModal

## Test plan
- [x] npm run lint — 0 errors, no unused imports
- [x] npm test — 90 passed (behavior unchanged)
- [x] npm run build — success

closes #91