### PR TITLE
fix(client): inject monaco instance instead of relying on window.monaco

### DIFF
--- a/client/src/__tests__/useAiAssistant.test.jsx
+++ b/client/src/__tests__/useAiAssistant.test.jsx
@@ -1,0 +1,115 @@
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import useAiAssistant from '../hooks/useAiAssistant';
+
+vi.mock('../utils/api', () => ({
+  apiRequest: vi.fn(),
+}));
+
+import { apiRequest } from '../utils/api';
+
+// Minimal fakes for the Monaco editor + monaco namespace.
+// The real instances are injected via setEditorInstance(editor, monaco) at onMount time.
+function makeFakeMonaco() {
+  // Range is the only monaco member the hook touches.
+  return {
+    Range: vi.fn(function Range(sl, sc, el, ec) {
+      this.startLineNumber = sl;
+      this.startColumn = sc;
+      this.endLineNumber = el;
+      this.endColumn = ec;
+    }),
+  };
+}
+
+function makeFakeEditor() {
+  return {
+    getValue: vi.fn(() => 'const a = 1;'),
+    deltaDecorations: vi.fn(() => ['dec-id']),
+    revealLineInCenterIfOutsideViewport: vi.fn(),
+  };
+}
+
+const hookArgs = () => ({
+  language: 'javascript',
+  setSource: vi.fn(),
+  setDirty: vi.fn(),
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Ensure the unreliable global is absent — the bug surfaced exactly when
+  // window.monaco was undefined after an F5 remount.
+  delete window.monaco;
+});
+
+describe('useAiAssistant — monaco instance injection (no window.monaco global)', () => {
+  test('triggerStyleReviewer draws decorations using the injected monaco, not window.monaco', async () => {
+    const editor = makeFakeEditor();
+    const monaco = makeFakeMonaco();
+
+    apiRequest.mockResolvedValueOnce({
+      readability: 80,
+      performance: 70,
+      maintainability: 75,
+      safety: 90,
+      annotations: [{ line: 1, severity: 'warning' }],
+    });
+
+    const { result } = renderHook(() => useAiAssistant(hookArgs()));
+
+    act(() => {
+      result.current.setEditorInstance(editor, monaco);
+    });
+
+    await act(async () => {
+      await result.current.triggerStyleReviewer();
+    });
+
+    // No error must be surfaced even though window.monaco is undefined.
+    expect(result.current.aiError).toBeNull();
+    expect(result.current.aiData.style).toMatchObject({ readability: 80 });
+    // Decoration must be built from the injected monaco's Range.
+    expect(monaco.Range).toHaveBeenCalledWith(1, 1, 1, 100);
+    expect(editor.deltaDecorations).toHaveBeenCalled();
+  });
+
+  test('triggerStyleReviewer does not throw when monaco is not injected yet (still returns score data)', async () => {
+    apiRequest.mockResolvedValueOnce({
+      readability: 60,
+      performance: 60,
+      maintainability: 60,
+      safety: 60,
+      annotations: [{ line: 2, severity: 'info' }],
+    });
+
+    const { result } = renderHook(() => useAiAssistant(hookArgs()));
+
+    // No setEditorInstance call — instance not ready.
+    await act(async () => {
+      await result.current.triggerStyleReviewer();
+    });
+
+    expect(result.current.aiError).toBeNull();
+    expect(result.current.aiData.style).toMatchObject({ readability: 60 });
+  });
+
+  test('highlightEditorLine uses the injected monaco instance', () => {
+    const editor = makeFakeEditor();
+    const monaco = makeFakeMonaco();
+
+    const { result } = renderHook(() => useAiAssistant(hookArgs()));
+
+    act(() => {
+      result.current.setEditorInstance(editor, monaco);
+    });
+
+    act(() => {
+      result.current.highlightEditorLine(3, 'cls');
+    });
+
+    expect(editor.revealLineInCenterIfOutsideViewport).toHaveBeenCalledWith(3);
+    expect(monaco.Range).toHaveBeenCalledWith(3, 1, 3, 100);
+    expect(editor.deltaDecorations).toHaveBeenCalled();
+  });
+});

--- a/client/src/components/Editor.jsx
+++ b/client/src/components/Editor.jsx
@@ -22,7 +22,8 @@ export default function Editor({ source, language, fontSize, theme, onChange, on
       onChange={(value) => onChange(value ?? '')}
       beforeMount={handleBeforeMount}
       
-      // 모나코 마운트 시 부모 컴포넌트로 editor 인스턴스를 올려보냄
+      // 모나코 마운트 시 부모 컴포넌트로 editor·monaco 인스턴스를 함께 올려보냄
+      // (전역 window.monaco는 채워진다는 보장이 없어 F5 재마운트 시 깨지므로 명시적으로 주입)
       onMount={(editor, monaco) => {
         if (onMount) {
           onMount(editor, monaco);

--- a/client/src/hooks/useAiAssistant.js
+++ b/client/src/hooks/useAiAssistant.js
@@ -16,10 +16,14 @@ export default function useAiAssistant({ language, setSource, setDirty }) {
   const [aiError, setAiError] = useState(null);
 
   const editorRef = useRef(null);
+  const monacoRef = useRef(null);
   const decorationsRef = useRef([]);
 
-  const setEditorInstance = (editor) => {
+  // editor와 monaco 인스턴스를 onMount 시점에 함께 주입받아 ref로 보관한다.
+  // 전역 window.monaco에 의존하면 F5 재마운트 시 비어 있어 데코레이션이 깨지므로 사용하지 않는다.
+  const setEditorInstance = (editor, monaco) => {
     editorRef.current = editor;
+    if (monaco) monacoRef.current = monaco;
   };
 
   const getLatestSource = () => {
@@ -33,12 +37,12 @@ export default function useAiAssistant({ language, setSource, setDirty }) {
   };
 
   const highlightEditorLine = (line, className) => {
-    if (!editorRef.current || !window.monaco) return;
+    if (!editorRef.current || !monacoRef.current) return;
     const editor = editorRef.current;
     editor.revealLineInCenterIfOutsideViewport(line);
     decorationsRef.current = editor.deltaDecorations(decorationsRef.current, [
       {
-        range: new window.monaco.Range(line, 1, line, 100),
+        range: new monacoRef.current.Range(line, 1, line, 100),
         options: { isWholeLine: true, className }
       }
     ]);
@@ -89,9 +93,11 @@ export default function useAiAssistant({ language, setSource, setDirty }) {
 
       setAiData(prev => ({ ...prev, style: data }));
 
-      if (data.annotations && data.annotations.length > 0) {
+      // 에디터·monaco 인스턴스가 아직 준비되지 않았으면(예: F5 직후) 데코레이션만 건너뛴다.
+      // 점수·텍스트 결과(setAiData)는 위에서 이미 반영되므로 리뷰 자체는 정상 표시된다.
+      if (data.annotations && data.annotations.length > 0 && editorRef.current && monacoRef.current) {
         const newDecorations = data.annotations.map(ann => ({
-          range: new window.monaco.Range(ann.line, 1, ann.line, 100),
+          range: new monacoRef.current.Range(ann.line, 1, ann.line, 100),
           options: {
             isWholeLine: true,
             className: ann.severity === 'warning' ? 'bg-amber-500/10 border-l-4 border-amber-500' : 'bg-blue-500/10 border-l-4 border-blue-500',

--- a/client/src/pages/CodeEditor.jsx
+++ b/client/src/pages/CodeEditor.jsx
@@ -209,7 +209,7 @@ export default function CodeEditor() {
               fontSize={editorFontSize}
               theme={editorTheme}
               onChange={handleSourceChange}
-              onMount={(editor) => setEditorInstance(editor)} 
+              onMount={(editor, monaco) => setEditorInstance(editor, monaco)}
             />
           </div>
           <div className={styles.resizer} role="separator" aria-orientation="horizontal" onMouseDown={startResize} />


### PR DESCRIPTION
## Summary
- Fix the AI style reviewer ("syntax corrector") and editor line decorations breaking after an F5 (full page reload).
- Root cause: the code read the global `window.monaco`, which is never assigned anywhere in the codebase. It only existed when the `@monaco-editor/react` loader happened to populate it, so on F5 remount it could be `undefined`, making `new window.monaco.Range(...)` throw a `TypeError` ("스타일 리뷰 실패").
- The real gap was in `CodeEditor.jsx`: `onMount` forwarded only `editor` and discarded the `monaco` instance, so the hook had no reliable way to obtain it.

### Changes
- `useAiAssistant.js`: add `monacoRef`, accept the instance via `setEditorInstance(editor, monaco)`, replace all `window.monaco` reads with `monacoRef.current`, and guard decoration building so it skips (without throwing) when the instance is not ready — score/text results still render.
- `CodeEditor.jsx`: pass `monaco` through `onMount` into `setEditorInstance`.
- `Editor.jsx`: clarify intent in a comment (no behavior change).
- Add `useAiAssistant.test.jsx` covering the regression with `window.monaco` deleted.

## Test plan
- [x] `npm run lint` — 0 errors
- [x] `npm run test` — 13 files / 109 tests pass (3 new hook tests included)
- [x] `npm run build` — succeeds
- [ ] Manual: open a saved code, press F5, run the style review — scores/comments/line decorations render with no "스타일 리뷰 실패" error

closes #109
